### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android-sdk-ui/AndroidManifest.xml
+++ b/android-sdk-ui/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.appboy.ui">
-  <application android:allowBackup="true"/>
+  <application />
 </manifest>
 


### PR DESCRIPTION
remove allowBackup to resolve issues with manifest collisions. 
if my Application has allowBackup=false the build will fail with manifest merger.