### PR TITLE
ProGuard: Replace -dontoptimize with -keep rules

### DIFF
--- a/android-sdk-ui/appboy-proguard-rules.pro
+++ b/android-sdk-ui/appboy-proguard-rules.pro
@@ -7,9 +7,12 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# turning off optimization because it can cause build failures for users using Google Play Services
-# with Appboy. See https://github.com/Appboy/appboy-android-sdk/issues/49
--dontoptimize
+# Keeping classes in com.appboy.ui and com.appboy.services because not keeping
+# them can cause build failures for users using Google Play Services with
+# Appboy. Alternative fix for:
+# https://github.com/Appboy/appboy-android-sdk/issues/49
+-keepnames class com.appboy.ui.** { *; }
+-keep class com.appboy.services.** { *; }
 
 -dontwarn com.amazon.device.messaging.**
 -dontwarn bo.app.**


### PR DESCRIPTION
Using -dontoptimize disables ProGuard optimization for all users of this
library. Instead configure keep rules to keep the classes from
com.appboy.ui and com.appboy.services.

This a very severe issue because in the project I'm currently working on we rely on ProGuard optimization for several reasons. Without -dontoptimize we had the same issue as in https://github.com/Appboy/appboy-android-sdk/issues/49 but the added keep rules fixed this.