### PR TITLE
Removed appboy methods from Main Activity to avoid forcing users to i…

### DIFF
--- a/android-sdk-unity/src/com/appboy/unity/AppboyUnityActivityWrapper.java
+++ b/android-sdk-unity/src/com/appboy/unity/AppboyUnityActivityWrapper.java
@@ -73,25 +73,4 @@ public class AppboyUnityActivityWrapper {
     // the new intent as the current one (which has the new intent extras).
     activity.setIntent(intent);
   }
-
-  /**
-   * See {@link AppboyUnityPlayerActivity#logInAppMessageClick(String)} or {@link AppboyUnityPlayerNativeActivity#logInAppMessageClick(String)}
-   */
-  public void logInAppMessageClick(String messageJSONString, Activity activity) {
-    InAppMessageUtils.logInAppMessageClick(InAppMessageUtils.inAppMessageFromString(activity, messageJSONString));
-  }
-
-  /**
-   * See {@link AppboyUnityPlayerActivity#logInAppMessageButtonClick(String, int)} or {@link AppboyUnityPlayerNativeActivity#logInAppMessageButtonClick(String, int)}
-   */
-  public void logInAppMessageButtonClick(String messageJSONString, int buttonId, Activity activity) {
-    InAppMessageUtils.logInAppMessageButtonClick(InAppMessageUtils.inAppMessageFromString(activity, messageJSONString), buttonId);
-  }
-
-  /**
-   * See {@link AppboyUnityPlayerActivity#logInAppMessageImpression(String)} or {@link AppboyUnityPlayerNativeActivity#logInAppMessageImpression(String)}
-   */
-  public void logInAppMessageImpression(String messageJSONString, Activity activity) {
-    InAppMessageUtils.logInAppMessageImpression(InAppMessageUtils.inAppMessageFromString(activity, messageJSONString));
-  }
 }

--- a/android-sdk-unity/src/com/appboy/unity/AppboyUnityPlayerActivity.java
+++ b/android-sdk-unity/src/com/appboy/unity/AppboyUnityPlayerActivity.java
@@ -52,16 +52,4 @@ public class AppboyUnityPlayerActivity extends UnityPlayerActivity {
     super.onNewIntent(intent);
     mAppboyUnityActivityWrapper.onNewIntentCalled(intent, this);
   }
-
-  public void logInAppMessageClick(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageClick(messageJSONString, this);
-  }
-
-  public void logInAppMessageButtonClick(String messageJSONString, int buttonId) {
-    mAppboyUnityActivityWrapper.logInAppMessageButtonClick(messageJSONString, buttonId, this);
-  }
-
-  public void logInAppMessageImpression(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageImpression(messageJSONString, this);
-  }
 }

--- a/android-sdk-unity/src/com/appboy/unity/AppboyUnityPlayerNativeActivity.java
+++ b/android-sdk-unity/src/com/appboy/unity/AppboyUnityPlayerNativeActivity.java
@@ -52,16 +52,4 @@ public class AppboyUnityPlayerNativeActivity extends UnityPlayerNativeActivity {
     super.onNewIntent(intent);
     mAppboyUnityActivityWrapper.onNewIntentCalled(intent, this);
   }
-
-  public void logInAppMessageClick(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageClick(messageJSONString, this);
-  }
-
-  public void logInAppMessageButtonClick(String messageJSONString, int buttonId) {
-    mAppboyUnityActivityWrapper.logInAppMessageButtonClick(messageJSONString, buttonId, this);
-  }
-
-  public void logInAppMessageImpression(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageImpression(messageJSONString, this);
-  }
 }

--- a/android-sdk-unity/src/com/appboy/unity/prime31compatible/AppboyUnityPlayerActivity.java
+++ b/android-sdk-unity/src/com/appboy/unity/prime31compatible/AppboyUnityPlayerActivity.java
@@ -54,16 +54,4 @@ public class AppboyUnityPlayerActivity extends UnityPlayerActivity {
     super.onNewIntent(intent);
     mAppboyUnityActivityWrapper.onNewIntentCalled(intent, this);
   }
-
-  public void logInAppMessageClick(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageClick(messageJSONString, this);
-  }
-
-  public void logInAppMessageButtonClick(String messageJSONString, int buttonId) {
-    mAppboyUnityActivityWrapper.logInAppMessageButtonClick(messageJSONString, buttonId, this);
-  }
-
-  public void logInAppMessageImpression(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageImpression(messageJSONString, this);
-  }
 }

--- a/android-sdk-unity/src/com/appboy/unity/prime31compatible/AppboyUnityPlayerNativeActivity.java
+++ b/android-sdk-unity/src/com/appboy/unity/prime31compatible/AppboyUnityPlayerNativeActivity.java
@@ -54,16 +54,4 @@ public class AppboyUnityPlayerNativeActivity extends UnityPlayerNativeActivity {
     super.onNewIntent(intent);
     mAppboyUnityActivityWrapper.onNewIntentCalled(intent, this);
   }
-
-  public void logInAppMessageClick(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageClick(messageJSONString, this);
-  }
-
-  public void logInAppMessageButtonClick(String messageJSONString, int buttonId) {
-    mAppboyUnityActivityWrapper.logInAppMessageButtonClick(messageJSONString, buttonId, this);
-  }
-
-  public void logInAppMessageImpression(String messageJSONString) {
-    mAppboyUnityActivityWrapper.logInAppMessageImpression(messageJSONString, this);
-  }
 }

--- a/android-sdk-unity/src/com/appboy/unity/utils/InAppMessageUtils.java
+++ b/android-sdk-unity/src/com/appboy/unity/utils/InAppMessageUtils.java
@@ -10,44 +10,52 @@ import com.appboy.models.MessageButton;
 import com.appboy.support.AppboyLogger;
 
 public class InAppMessageUtils {
-  private static final String TAG = AppboyLogger.getAppboyLogTag(InAppMessageUtils.class);
+    private static final String TAG = AppboyLogger.getAppboyLogTag(InAppMessageUtils.class);
+    private static Context _context;
 
-  public static IInAppMessage inAppMessageFromString(Context context, String messageJSONString) {
-    return Appboy.getInstance(context).deserializeInAppMessageString(messageJSONString);
-  }
-
-  public static void logInAppMessageClick(IInAppMessage inAppMessage) {
-    if (inAppMessage != null) {
-      inAppMessage.logClick();
-    } else {
-      Log.e(TAG, "The in-app message is null, Not logging in-app message click.");
+    public static void setContext(Context context) {
+        _context = context;
     }
-  }
 
-  public static void logInAppMessageButtonClick(IInAppMessage inAppMessage, int buttonId) {
-    if (inAppMessage == null) {
-      Log.e(TAG, "The in-app message is null. Not logging in-app message button click.");
-      return;
+    public static IInAppMessage inAppMessageFromString(String messageJSONString) {
+        return Appboy.getInstance(_context).deserializeInAppMessageString(messageJSONString);
     }
-    if (inAppMessage instanceof IInAppMessageImmersive) {
-      IInAppMessageImmersive inAppMessageImmersive = (IInAppMessageImmersive)inAppMessage;
-      for (MessageButton button : inAppMessageImmersive.getMessageButtons()) {
-        if (button.getId() == buttonId) {
-          inAppMessageImmersive.logButtonClick(button);
-          break;
+
+    public static void logInAppMessageClick(String messageJSONString) {
+        IInAppMessage inAppMessage = inAppMessageFromString(messageJSONString);
+        if (inAppMessage != null) {
+            inAppMessage.logClick();
+        } else {
+            Log.e(TAG, "The in-app message is null, Not logging in-app message click.");
         }
-      }
-    } else {
-      Log.e(TAG, "The in-app message %s isn't an instance of "
-          + "InAppMessageImmersive. Not logging in-app message button click.");
     }
-  }
 
-  public static void logInAppMessageImpression(IInAppMessage inAppMessage) {
-    if (inAppMessage != null) {
-      inAppMessage.logImpression();
-    } else {
-      Log.e(TAG, "The in-app message is null, Not logging in-app message impression.");
+    public static void logInAppMessageButtonClick(String messageJSONString, int buttonId) {
+        IInAppMessage inAppMessage = inAppMessageFromString(messageJSONString);
+        if (inAppMessage == null) {
+            Log.e(TAG, "The in-app message is null. Not logging in-app message button click.");
+            return;
+        }
+        if (inAppMessage instanceof IInAppMessageImmersive) {
+            IInAppMessageImmersive inAppMessageImmersive = (IInAppMessageImmersive) inAppMessage;
+            for (MessageButton button : inAppMessageImmersive.getMessageButtons()) {
+                if (button.getId() == buttonId) {
+                    inAppMessageImmersive.logButtonClick(button);
+                    break;
+                }
+            }
+        } else {
+            Log.e(TAG, "The in-app message %s isn't an instance of "
+                    + "InAppMessageImmersive. Not logging in-app message button click.");
+        }
     }
-  }
+
+    public static void logInAppMessageImpression(String messageJSONString) {
+        IInAppMessage inAppMessage = inAppMessageFromString(messageJSONString);
+        if (inAppMessage != null) {
+            inAppMessage.logImpression();
+        } else {
+            Log.e(TAG, "The in-app message is null, Not logging in-app message impression.");
+        }
+    }
 }

--- a/android-sdk-unity/src/com/appboy/unity/utils/InAppMessageUtils.java
+++ b/android-sdk-unity/src/com/appboy/unity/utils/InAppMessageUtils.java
@@ -11,18 +11,12 @@ import com.appboy.support.AppboyLogger;
 
 public class InAppMessageUtils {
     private static final String TAG = AppboyLogger.getAppboyLogTag(InAppMessageUtils.class);
-    private static Context _context;
 
-    public static void setContext(Context context) {
-        _context = context;
+    public static IInAppMessage inAppMessageFromString(Context context, String messageJSONString) {
+        return Appboy.getInstance(context).deserializeInAppMessageString(messageJSONString);
     }
 
-    public static IInAppMessage inAppMessageFromString(String messageJSONString) {
-        return Appboy.getInstance(_context).deserializeInAppMessageString(messageJSONString);
-    }
-
-    public static void logInAppMessageClick(String messageJSONString) {
-        IInAppMessage inAppMessage = inAppMessageFromString(messageJSONString);
+    public static void logInAppMessageClick(IInAppMessage inAppMessage) {
         if (inAppMessage != null) {
             inAppMessage.logClick();
         } else {
@@ -30,14 +24,13 @@ public class InAppMessageUtils {
         }
     }
 
-    public static void logInAppMessageButtonClick(String messageJSONString, int buttonId) {
-        IInAppMessage inAppMessage = inAppMessageFromString(messageJSONString);
+    public static void logInAppMessageButtonClick(IInAppMessage inAppMessage, int buttonId) {
         if (inAppMessage == null) {
             Log.e(TAG, "The in-app message is null. Not logging in-app message button click.");
             return;
         }
         if (inAppMessage instanceof IInAppMessageImmersive) {
-            IInAppMessageImmersive inAppMessageImmersive = (IInAppMessageImmersive) inAppMessage;
+            IInAppMessageImmersive inAppMessageImmersive = (IInAppMessageImmersive)inAppMessage;
             for (MessageButton button : inAppMessageImmersive.getMessageButtons()) {
                 if (button.getId() == buttonId) {
                     inAppMessageImmersive.logButtonClick(button);
@@ -50,8 +43,7 @@ public class InAppMessageUtils {
         }
     }
 
-    public static void logInAppMessageImpression(String messageJSONString) {
-        IInAppMessage inAppMessage = inAppMessageFromString(messageJSONString);
+    public static void logInAppMessageImpression(IInAppMessage inAppMessage) {
         if (inAppMessage != null) {
             inAppMessage.logImpression();
         } else {

--- a/android-sdk-unity/src/com/appboy/unity/utils/InAppMessageUtils.java
+++ b/android-sdk-unity/src/com/appboy/unity/utils/InAppMessageUtils.java
@@ -10,44 +10,44 @@ import com.appboy.models.MessageButton;
 import com.appboy.support.AppboyLogger;
 
 public class InAppMessageUtils {
-    private static final String TAG = AppboyLogger.getAppboyLogTag(InAppMessageUtils.class);
+  private static final String TAG = AppboyLogger.getAppboyLogTag(InAppMessageUtils.class);
 
-    public static IInAppMessage inAppMessageFromString(Context context, String messageJSONString) {
-        return Appboy.getInstance(context).deserializeInAppMessageString(messageJSONString);
-    }
+  public static IInAppMessage inAppMessageFromString(Context context, String messageJSONString) {
+    return Appboy.getInstance(context).deserializeInAppMessageString(messageJSONString);
+  }
 
-    public static void logInAppMessageClick(IInAppMessage inAppMessage) {
-        if (inAppMessage != null) {
-            inAppMessage.logClick();
-        } else {
-            Log.e(TAG, "The in-app message is null, Not logging in-app message click.");
-        }
+  public static void logInAppMessageClick(IInAppMessage inAppMessage) {
+    if (inAppMessage != null) {
+      inAppMessage.logClick();
+    } else {
+      Log.e(TAG, "The in-app message is null, Not logging in-app message click.");
     }
+  }
 
-    public static void logInAppMessageButtonClick(IInAppMessage inAppMessage, int buttonId) {
-        if (inAppMessage == null) {
-            Log.e(TAG, "The in-app message is null. Not logging in-app message button click.");
-            return;
-        }
-        if (inAppMessage instanceof IInAppMessageImmersive) {
-            IInAppMessageImmersive inAppMessageImmersive = (IInAppMessageImmersive)inAppMessage;
-            for (MessageButton button : inAppMessageImmersive.getMessageButtons()) {
-                if (button.getId() == buttonId) {
-                    inAppMessageImmersive.logButtonClick(button);
-                    break;
-                }
-            }
-        } else {
-            Log.e(TAG, "The in-app message %s isn't an instance of "
-                    + "InAppMessageImmersive. Not logging in-app message button click.");
-        }
+  public static void logInAppMessageButtonClick(IInAppMessage inAppMessage, int buttonId) {
+    if (inAppMessage == null) {
+      Log.e(TAG, "The in-app message is null. Not logging in-app message button click.");
+      return;
     }
+    if (inAppMessage instanceof IInAppMessageImmersive) {
+      IInAppMessageImmersive inAppMessageImmersive = (IInAppMessageImmersive)inAppMessage;
+      for (MessageButton button : inAppMessageImmersive.getMessageButtons()) {
+        if (button.getId() == buttonId) {
+          inAppMessageImmersive.logButtonClick(button);
+          break;
+        }
+      }
+    } else {
+      Log.e(TAG, "The in-app message %s isn't an instance of "
+          + "InAppMessageImmersive. Not logging in-app message button click.");
+    }
+  }
 
-    public static void logInAppMessageImpression(IInAppMessage inAppMessage) {
-        if (inAppMessage != null) {
-            inAppMessage.logImpression();
-        } else {
-            Log.e(TAG, "The in-app message is null, Not logging in-app message impression.");
-        }
+  public static void logInAppMessageImpression(IInAppMessage inAppMessage) {
+    if (inAppMessage != null) {
+      inAppMessage.logImpression();
+    } else {
+      Log.e(TAG, "The in-app message is null, Not logging in-app message impression.");
     }
+  }
 }


### PR DESCRIPTION
Fix for issue: https://github.com/Appboy/appboy-android-sdk/issues/95
Related to issue: https://github.com/Appboy/appboy-unity-sdk/issues/37

* Appboy concrete methods were removed from Main Activities (every xxxUnityPlayerActivity).

* `InAppMessagesUtils` now will receive Strings instead of `IInAppMessage`. 
  * Each `logInAppMessageXXX` method will create the `IInAppMessage` object.

