### PR TITLE
Disabled waking of TV panels

### DIFF
--- a/android-sdk-ui/src/main/java/com/braze/push/BrazeNotificationUtils.java
+++ b/android-sdk-ui/src/main/java/com/braze/push/BrazeNotificationUtils.java
@@ -8,8 +8,10 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.app.UiModeManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
@@ -322,6 +324,12 @@ public class BrazeNotificationUtils {
       return false;
     }
     if (!configurationProvider.isPushWakeScreenForNotificationEnabled()) {
+      return false;
+    }
+
+    // Never wake a TV panel
+    UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+    if (uiModeManager != null && uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
       return false;
     }
 


### PR DESCRIPTION
The wakeScreenIfAppropriate method would turn on TV panels on Android TV
OS devices. Since notifications don't show on Android TV OS devices,
this results in a TV turning on (or switching HDMI inputs) for seemingly
no reason. This change prevents that undesired behavior.