### PR TITLE
Implementing onRenderProcessGone to avoid application crash

### DIFF
--- a/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/utils/InAppMessageWebViewClient.java
+++ b/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/utils/InAppMessageWebViewClient.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -205,5 +207,13 @@ public class InAppMessageWebViewClient extends WebViewClient {
       queryBundle.putString(queryKeyName, queryValue);
     }
     return queryBundle;
+  }
+
+  @Override
+  public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+      Log.e(TAG, "The webview rendering process crashed");
+
+      //The app crashes after detecting the renderer crashed.Returning true to avoid app crash
+      return true;
   }
 }

--- a/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/utils/InAppMessageWebViewClient.java
+++ b/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/utils/InAppMessageWebViewClient.java
@@ -5,7 +5,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
 import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
@@ -28,6 +27,10 @@ import com.braze.ui.support.UriUtils;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 
 public class InAppMessageWebViewClient extends WebViewClient {
   private static final String TAG = BrazeLogger.getBrazeLogTag(InAppMessageWebViewClient.class);
@@ -211,7 +214,8 @@ public class InAppMessageWebViewClient extends WebViewClient {
 
   @Override
   public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
-      Log.e(TAG, "The webview rendering process crashed");
+
+      BrazeLogger.i(TAG, "The webview rendering process crashed, returning true" );
 
       //The app crashes after detecting the renderer crashed.Returning true to avoid app crash
       return true;


### PR DESCRIPTION
Providing implementation of onRenderProcessGone to avoid host application crash, as multiple WebView instances may be associated with a single render process; onRenderProcessGone will be called for each WebView that was affected and if it swallows the renderer crash instead of handling it the host application will crash.